### PR TITLE
Deactivate BESS wiki update workflow and unpublish wiki post

### DIFF
--- a/.github/workflows/bess-wiki-update.yml.disabled
+++ b/.github/workflows/bess-wiki-update.yml.disabled
@@ -1,3 +1,7 @@
+# DEACTIVATED — this file ends in `.disabled`, so GitHub Actions ignores it and
+# it never runs (no scheduled or manual runs). To reactivate, rename it back to
+# `bess-wiki-update.yml` and configure the secret/variable noted below.
+
 name: Update BESS Wiki
 
 # Distills raw session notes dropped into wiki-inbox/ into the living glossary at

--- a/src/content/posts/bess-wiki.md
+++ b/src/content/posts/bess-wiki.md
@@ -4,7 +4,8 @@ description: "A continuously-updated working glossary of battery energy storage 
 pubDate: 2026-06-15
 updatedDate: 2026-06-15
 tags: ["bess", "energy-storage", "wiki", "reference"]
-featured: true
+featured: false
+draft: true
 ---
 
 <!--


### PR DESCRIPTION
This PR deactivates the BESS wiki update automation workflow and unpublishes the associated wiki post.

## Summary
The BESS wiki update workflow and its corresponding documentation post are being temporarily deactivated pending reconfiguration of required secrets/variables.

## Key Changes
- **Workflow deactivation**: Renamed `bess-wiki-update.yml` to `bess-wiki-update.yml.disabled` and added a comment explaining the deactivation status and reactivation steps
- **Post unpublishing**: Marked the BESS wiki post as a draft and removed it from featured content to prevent it from being published while the workflow is inactive

## Implementation Details
- The workflow file now includes clear documentation at the top explaining why it's disabled and what needs to be done to reactivate it
- The post's `featured` flag is set to `false` and `draft` flag is set to `true`, ensuring it won't appear in the published site

https://claude.ai/code/session_01JKk7fo5NPc3R7bsTtK93om